### PR TITLE
Add vitest and CPF helper tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "vitest"
   },
   "prisma": {
     "seed": "ts-node ./prisma/seed.ts"
@@ -48,6 +49,7 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/app/[slug]/menu/helpers/cpf.test.ts
+++ b/src/app/[slug]/menu/helpers/cpf.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isValidCpf, removeCpfPunctuation } from './cpf';
+
+describe('removeCpfPunctuation', () => {
+  it('strips dots and hyphen from CPF string', () => {
+    expect(removeCpfPunctuation('123.456.789-09')).toBe('12345678909');
+    expect(removeCpfPunctuation('935.411.347-80')).toBe('93541134780');
+  });
+});
+
+describe('isValidCpf', () => {
+  it('returns true for valid CPF numbers', () => {
+    const valids = ['529.982.247-25', '12345678909', '935.411.347-80'];
+    valids.forEach((cpf) => expect(isValidCpf(cpf)).toBe(true));
+  });
+
+  it('returns false for invalid CPF numbers', () => {
+    const invalids = ['000.000.000-00', '11111111111', '123.456.789-00'];
+    invalids.forEach((cpf) => expect(isValidCpf(cpf)).toBe(false));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- introduce Vitest test runner
- configure Vitest
- add unit tests for CPF helpers

## Testing
- `npm test` *(fails: vitest not found)*