### PR TITLE
Rename Restaurant model to Store

### DIFF
--- a/prisma/migrations/20250518000000_rename_restaurant_to_store/migration.sql
+++ b/prisma/migrations/20250518000000_rename_restaurant_to_store/migration.sql
@@ -1,0 +1,19 @@
+-- Rename table Restaurant to Store and update foreign keys
+
+-- Rename table
+ALTER TABLE "Restaurant" RENAME TO "Store";
+
+-- MenuCategory adjustments
+ALTER TABLE "MenuCategory" DROP CONSTRAINT "MenuCategory_restaurantId_fkey";
+ALTER TABLE "MenuCategory" RENAME COLUMN "restaurantId" TO "storeId";
+ALTER TABLE "MenuCategory" ADD CONSTRAINT "MenuCategory_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Product adjustments
+ALTER TABLE "Product" DROP CONSTRAINT "Product_restaurantId_fkey";
+ALTER TABLE "Product" RENAME COLUMN "restaurantId" TO "storeId";
+ALTER TABLE "Product" ADD CONSTRAINT "Product_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Order adjustments
+ALTER TABLE "Order" DROP CONSTRAINT "Order_restaurantId_fkey";
+ALTER TABLE "Order" RENAME COLUMN "restaurantId" TO "storeId";
+ALTER TABLE "Order" ADD CONSTRAINT "Order_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Restaurant {
+model Store {
   id             String         @id @default(uuid())
   name           String
   slug           String
@@ -30,8 +30,8 @@ model Restaurant {
 model MenuCategory {
   id           String     @id @default(uuid())
   name         String
-  restaurant   Restaurant @relation(fields: [restaurantId], references: [id], onDelete: Cascade)
-  restaurantId String
+  store        Store      @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  storeId      String
   createdAt    DateTime   @default(now())
   updateAt     DateTime   @updatedAt
   products     Product[]
@@ -44,8 +44,8 @@ model Product {
   price          Float
   imageUrl       String
   ingredients   String []
-  restaurant     Restaurant     @relation(fields: [restaurantId], references: [id], onDelete: Cascade)
-  restaurantId   String
+  store          Store          @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  storeId        String
   menuCategory   MenuCategory   @relation(fields: [menuCategoryId], references: [id], onDelete: Cascade)
   menuCategoryId String
   orderProduct   OrderProduct[]
@@ -59,8 +59,8 @@ model Order {
   status            OrderStatus
   consumptionMethod ConsumptionMethod
   orderProduct      OrderProduct[]
-  restaurant        Restaurant        @relation(fields: [restaurantId], references: [id], onDelete: Cascade)
-  restaurantId      String
+  store             Store             @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  storeId           String
   customerName      String
   customerCpf       String
   createdAt         DateTime          @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,8 +8,8 @@ const prismaClient = new PrismaClient();
 
 const main = async () => {
   await prismaClient.$transaction(async (tx: any) => {
-    await tx.restaurant.deleteMany();
-    const restaurant = await tx.restaurant.create({
+    await tx.store.deleteMany();
+    const store = await tx.store.create({
       data: {
         name: "FSW Donalds",
         slug: "fsw-donalds",
@@ -23,7 +23,7 @@ const main = async () => {
     const combosCategory = await tx.menuCategory.create({
       data: {
         name: "Combos",
-        restaurantId: restaurant.id,
+        storeId: store.id,
       },
     });
     await tx.product.createMany({
@@ -36,7 +36,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQaHB8tslkBUjlHSKiuseLm2hIFzVY0OtxEPnw",
           menuCategoryId: combosCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
           ingredients: [
             "Pão com gergilim",
             "Hambúrguer de carne 100% bovina",
@@ -55,7 +55,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQeGQofnEPyQaHEV2WL8rGUs41oMICtYfNkphl",
           menuCategoryId: combosCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
           ingredients: [
             "Pão tipo brioche",
             "Hambúrguer de carne 100% bovina",
@@ -75,7 +75,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQr12aTqPo3SsGjBJCaM7yhxnbDlXeL5N9dckv",
           menuCategoryId: combosCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
           ingredients: [
             "Pão tipo brioche",
             "Batata",
@@ -95,7 +95,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQWdq0w8niS9XCLQu7Nb4jvBYZze16goaOqsKR",
           menuCategoryId: combosCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
           ingredients: [
             "Pão escuro com gergelim",
             "Hambúrguer de carne 100% bovina",
@@ -108,7 +108,7 @@ const main = async () => {
     const hamburguersCategory = await tx.menuCategory.create({
       data: {
         name: "Lanches",
-        restaurantId: restaurant.id,
+        storeId: store.id,
       },
     });
     await tx.product.createMany({
@@ -130,7 +130,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQKfI6fivqActTvBGLXfQe4a8CJ6d3HiR7USPK",
           menuCategoryId: hamburguersCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Duplo Quarterão",
@@ -150,7 +150,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQ99rtECuYaDgmA4VujBU0wKn2ThXJvF3LHfyc",
           menuCategoryId: hamburguersCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "McMelt",
@@ -170,7 +170,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQUY0VlDTmvPeJLoyOjzNsMqFdxUI423nBl6br",
           menuCategoryId: hamburguersCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "McNífico Bacon",
@@ -186,14 +186,14 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQBBmifbjzEVXRoycAtrP9vH45bZ6WDl3QF0a1",
           menuCategoryId: hamburguersCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
       ],
     });
     const frenchFriesCategory = await tx.menuCategory.create({
       data: {
         name: "Fritas",
-        restaurantId: restaurant.id,
+        storeId: store.id,
       },
     });
     await tx.product.createMany({
@@ -206,7 +206,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQNd3jSNrcJroaszwjUAlM6iSO5ZTx2HV70t31",
           menuCategoryId: frenchFriesCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Fritas Média",
@@ -217,7 +217,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQ7Y6lv9tkc0L9oMIXZsFJtwnBh2KCz3y6uSW1",
           menuCategoryId: frenchFriesCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Fritas Pequena",
@@ -228,14 +228,14 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQ5toOZxYa1oARJCUGh4EY3x8NjXHtvZ7lnVfw",
           menuCategoryId: frenchFriesCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
       ],
     });
     const drinksCategory = await tx.menuCategory.create({
       data: {
         name: "Bebidas",
-        restaurantId: restaurant.id,
+        storeId: store.id,
       },
     });
     await tx.product.createMany({
@@ -248,7 +248,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQJS1b33q29eEsh0CVmOywrqx1UPnJpRGcHN5v",
           menuCategoryId: drinksCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Fanta Laranja",
@@ -258,7 +258,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQW7Kxm9gniS9XCLQu7Nb4jvBYZze16goaOqsK",
           menuCategoryId: drinksCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Água Mineral",
@@ -268,14 +268,14 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQ7i05S5tkc0L9oMIXZsFJtwnBh2KCz3y6uSW1",
           menuCategoryId: drinksCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
       ],
     });
     const dessertsCategory = await tx.menuCategory.create({
       data: {
         name: "Sobremesas",
-        restaurantId: restaurant.id,
+        storeId: store.id,
       },
     });
     await tx.product.createMany({
@@ -288,7 +288,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQtfuQrAKkI75oJfPT0crZxvX82ui9qV3hLFdY",
           menuCategoryId: dessertsCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Casquinha de Chocolate",
@@ -298,7 +298,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQBH21ijzEVXRoycAtrP9vH45bZ6WDl3QF0a1M",
           menuCategoryId: dessertsCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
         {
           name: "Casquinha de Mista",
@@ -308,7 +308,7 @@ const main = async () => {
           imageUrl:
             "https://u9a6wmr3as.ufs.sh/f/jppBrbk0cChQ4rBrtULypXmR6JiWuhzS8ALjVkrF3yfatC7E",
           menuCategoryId: dessertsCategory.id,
-          restaurantId: restaurant.id,
+          storeId: store.id,
         },
       ],
     });

--- a/src/app/[slug]/menu/[productId]/components/products-details.tsx
+++ b/src/app/[slug]/menu/[productId]/components/products-details.tsx
@@ -16,10 +16,11 @@ import { CartContext } from "../../contexts/cart";
 interface ProductDetailsProps {
   product: Prisma.ProductGetPayload<{
     include: {
-      restaurant: {
+      store: {
         select: {
           name: true;
           avatarImageUrl: true;
+          slug: true;
         };
       };
     };
@@ -59,14 +60,14 @@ const ProductDetails = ({ product }: ProductDetailsProps) => {
           {/* RESTAURANT */}
           <div className="flex items-center gap-1.5">
             <Image
-              src={product.restaurant.avatarImageUrl}
-              alt={product.restaurant.name}
+              src={product.store.avatarImageUrl}
+              alt={product.store.name}
               width={16}
               height={16}
               className="rounded-full"
             />
             <p className="text-xs text-muted-foreground">
-              {product.restaurant.name}
+              {product.store.name}
             </p>
           </div>
 

--- a/src/app/[slug]/menu/[productId]/page.tsx
+++ b/src/app/[slug]/menu/[productId]/page.tsx
@@ -17,7 +17,7 @@ const ProductPage = async ({ params }: ProductPageProps) => {
   const product = await db.product.findUnique({
     where: { id: productId },
     include: {
-      restaurant: {
+      store: {
         select: {
           name: true,
           avatarImageUrl: true,
@@ -33,7 +33,7 @@ const ProductPage = async ({ params }: ProductPageProps) => {
     return notFound();
   }
 
-  if (product.restaurant.slug.toUpperCase() !== slug.toUpperCase()) {
+  if (product.store.slug.toUpperCase() !== slug.toUpperCase()) {
     return notFound();
   }
 

--- a/src/app/[slug]/menu/actions/create-order.ts
+++ b/src/app/[slug]/menu/actions/create-order.ts
@@ -20,7 +20,7 @@ interface CreateOrderInput {
 }
 
 export const createOrder = async (input: CreateOrderInput) => {
-  const restaurant = await db.restaurant.findFirst({
+  const restaurant = await db.store.findFirst({
     where: {
       slug: input.slug,
     },
@@ -56,7 +56,7 @@ export const createOrder = async (input: CreateOrderInput) => {
         0,
       ),
       consumptionMethod: input.consumptionMethod,
-      restaurantId: restaurant.id,
+      storeId: restaurant.id,
     },
   });
   revalidatePath(`/${input.slug}/orders`);

--- a/src/app/[slug]/menu/components/categories.tsx
+++ b/src/app/[slug]/menu/components/categories.tsx
@@ -14,7 +14,7 @@ import CartSheet from "./cart-sheet";
 import Products from "./products";
 
 interface RestaurantCategoriesProps {
-  restaurant: Prisma.RestaurantGetPayload<{
+  restaurant: Prisma.StoreGetPayload<{
     include: {
       menuCategories: {
         include: { products: true };

--- a/src/app/[slug]/menu/components/header.tsx
+++ b/src/app/[slug]/menu/components/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Restaurant } from "@prisma/client";
+import type { Store } from "@prisma/client";
 import { ChevronLeftIcon, ScrollTextIcon } from "lucide-react";
 import Image from "next/image";
 import { useParams, useRouter } from "next/navigation";
@@ -8,7 +8,7 @@ import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 interface RestaurantHeaderProps {
-  restaurant: Pick<Restaurant, "name" | "coverImageUrl">;
+  restaurant: Pick<Store, "name" | "coverImageUrl">;
 }
 
 const RestaurantHeader = ({ restaurant }: RestaurantHeaderProps) => {

--- a/src/app/[slug]/menu/page.tsx
+++ b/src/app/[slug]/menu/page.tsx
@@ -23,7 +23,7 @@ const RestaurantMenuPage = async ({
   if (!isConsumptionMethodValid(consumptionMethod)) {
     return notFound();
   }
-  const restaurant = await db.restaurant.findFirst({
+  const restaurant = await db.store.findFirst({
     where: { slug },
     include: {
       menuCategories: {

--- a/src/app/[slug]/orders/components/order-list.tsx
+++ b/src/app/[slug]/orders/components/order-list.tsx
@@ -14,7 +14,7 @@ interface OrderListProps {
   orders: Array<
     Prisma.OrderGetPayload<{
       include: {
-        restaurant: {
+        store: {
           select: {
             name: true;
             avatarImageUrl: true;
@@ -65,13 +65,13 @@ const OrderList = ({ orders }: OrderListProps) => {
             <div className="flex items-center gap-2">
               <div className="relative h-5 w-5">
                 <Image
-                  src={order.restaurant.avatarImageUrl}
-                  alt={order.restaurant.name}
+                  src={order.store.avatarImageUrl}
+                  alt={order.store.name}
                   className="rounded-sm"
                   fill
                 />
               </div>
-              <p className="text-sm font-semibold">{order.restaurant.name}</p>
+              <p className="text-sm font-semibold">{order.store.name}</p>
             </div>
             <Separator />
             <div className="space-y-2">

--- a/src/app/[slug]/orders/page.tsx
+++ b/src/app/[slug]/orders/page.tsx
@@ -27,7 +27,7 @@ const OrdersPage = async ({ searchParams }: OrdersPageProps) => {
       customerCpf: removeCpfPunctuation(cpf),
     },
     include: {
-      restaurant: {
+      store: {
         select: {
           name: true,
           avatarImageUrl: true,

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -11,7 +11,7 @@ interface RestaurantPageProps {
 
 const RestaurantPage = async ({ params }: RestaurantPageProps) => {
   const { slug } = await params;
-  const restaurant = await db.restaurant.findFirst({ where: { slug } });
+  const restaurant = await db.store.findFirst({ where: { slug } });
   if (!restaurant) {
     return notFound();
   }

--- a/src/data/get-restaurant-by-slug.ts
+++ b/src/data/get-restaurant-by-slug.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/prisma";
 
 export const getRestaurantBySlug = async (slug: string) => {
-  const restaurant = await db.restaurant.findFirst({ where: { slug } });
+  const restaurant = await db.store.findFirst({ where: { slug } });
   return restaurant;
 };


### PR DESCRIPTION
## Notes
- Prisma model `Restaurant` renamed to `Store` with updated relations
- Added migration to rename table and foreign keys
- Updated queries and types in `src/` to use the new model
- Seed script adjusted for `store` references

## Testing
- `npm run lint` *(fails: `next` not found)*